### PR TITLE
[HU-0011]: Generación de reportes de rendimiento de forma programada

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':sqs-sender')
+	implementation project(':metrics-notifications')
 	implementation project(':sqs-listener')
 	implementation project(':dynamo-db')
 	implementation project(':metrics')

--- a/applications/app-service/src/main/java/co/com/crediya/MainApplication.java
+++ b/applications/app-service/src/main/java/co/com/crediya/MainApplication.java
@@ -3,9 +3,11 @@ package co.com.crediya;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class MainApplication {
     public static void main(String[] args) {
         SpringApplication.run(MainApplication.class, args);

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,6 +14,8 @@ management:
     health:
       probes:
         enabled: true
+app:
+  tz: "${APP_TZ:UTC}"
 cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS}"
 jwt:
@@ -23,8 +25,12 @@ aws:
 entrypoint:
   sqs:
     region: "${AWS_DEFAULT_REGION}"
-    queueUrl: "${AWS_SQS_LOAN_APPLICATIONS_APPROVED_QUEUE_URL}"
+    approvedQueueUrl: "${AWS_SQS_LOAN_APPLICATIONS_APPROVED_QUEUE_URL}"
     waitTimeSeconds: 20
     maxNumberOfMessages: 10
     visibilityTimeoutSeconds: 10
     numberOfThreads: 1
+adapter:
+  sqs:
+    region: "${AWS_DEFAULT_REGION}"
+    metricsNotificationQueueUrl: "${AWS_SQS_LOAN_APPLICATIONS_APPROVED_METRICS_QUEUE_URL}"

--- a/applications/app-service/src/test/java/co/com/crediya/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/crediya/config/UseCasesConfigTest.java
@@ -1,6 +1,7 @@
 package co.com.crediya.config;
 
 import co.com.crediya.model.approvedloanrequestmetric.gateways.ApprovedLoanRequestMetricRepository;
+import co.com.crediya.model.approvedloanrequestmetric.gateways.ApprovedLoanRequestMetricsEventPublisher;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +41,11 @@ public class UseCasesConfigTest {
         @Bean
         public ApprovedLoanRequestMetricRepository approvedLoanRequestMetricRepository() {
             return mock(ApprovedLoanRequestMetricRepository.class);
+        }
+
+        @Bean
+        public ApprovedLoanRequestMetricsEventPublisher approvedLoanRequestMetricsEventPublisher() {
+            return mock(ApprovedLoanRequestMetricsEventPublisher.class);
         }
     }
 

--- a/domain/model/src/main/java/co/com/crediya/model/approvedloanrequestmetric/events/ApprovedLoanRequestMetricsNotificationEvent.java
+++ b/domain/model/src/main/java/co/com/crediya/model/approvedloanrequestmetric/events/ApprovedLoanRequestMetricsNotificationEvent.java
@@ -1,0 +1,11 @@
+package co.com.crediya.model.approvedloanrequestmetric.events;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+public record ApprovedLoanRequestMetricsNotificationEvent(
+        Long approvedLoanCount,
+        BigDecimal approvedLoanAmount,
+        Date timestamp
+) {
+}

--- a/domain/model/src/main/java/co/com/crediya/model/approvedloanrequestmetric/gateways/ApprovedLoanRequestMetricsEventPublisher.java
+++ b/domain/model/src/main/java/co/com/crediya/model/approvedloanrequestmetric/gateways/ApprovedLoanRequestMetricsEventPublisher.java
@@ -1,0 +1,8 @@
+package co.com.crediya.model.approvedloanrequestmetric.gateways;
+
+import co.com.crediya.model.approvedloanrequestmetric.events.ApprovedLoanRequestMetricsNotificationEvent;
+import reactor.core.publisher.Mono;
+
+public interface ApprovedLoanRequestMetricsEventPublisher {
+    Mono<Void> publishNotification(ApprovedLoanRequestMetricsNotificationEvent event);
+}

--- a/domain/usecase/src/main/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCase.java
@@ -1,0 +1,31 @@
+package co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification;
+
+import co.com.crediya.contract.ReactiveUseCase;
+import co.com.crediya.model.approvedloanrequestmetric.events.ApprovedLoanRequestMetricsNotificationEvent;
+import co.com.crediya.model.approvedloanrequestmetric.gateways.ApprovedLoanRequestMetricsEventPublisher;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+import java.util.Date;
+
+@RequiredArgsConstructor
+public class SendLoanApplicationApprovedMetricsNotificationUseCase
+        implements ReactiveUseCase<SendLoanApplicationApprovedMetricsNotificationUseCaseInput, Mono<Void>> {
+    private final ApprovedLoanRequestMetricsEventPublisher publisher;
+
+    @Override
+    public Mono<Void> execute(SendLoanApplicationApprovedMetricsNotificationUseCaseInput input) {
+        return mapToEvent(input)
+                .flatMap(publisher::publishNotification);
+    }
+
+    private Mono<ApprovedLoanRequestMetricsNotificationEvent> mapToEvent(
+            SendLoanApplicationApprovedMetricsNotificationUseCaseInput input
+    ) {
+        return Mono.just(new ApprovedLoanRequestMetricsNotificationEvent(
+                input.approvedLoanCount(),
+                input.approvedLoanAmount(),
+                new Date()
+        ));
+    }
+}

--- a/domain/usecase/src/main/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCaseInput.java
+++ b/domain/usecase/src/main/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCaseInput.java
@@ -1,0 +1,9 @@
+package co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification;
+
+import java.math.BigDecimal;
+
+public record SendLoanApplicationApprovedMetricsNotificationUseCaseInput(
+        Long approvedLoanCount,
+        BigDecimal approvedLoanAmount
+) {
+}

--- a/domain/usecase/src/test/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/crediya/usecase/sendloanapplicationapprovedmetricsnotification/SendLoanApplicationApprovedMetricsNotificationUseCaseTest.java
@@ -1,0 +1,40 @@
+package co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification;
+
+import co.com.crediya.model.approvedloanrequestmetric.gateways.ApprovedLoanRequestMetricsEventPublisher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SendLoanApplicationApprovedMetricsNotificationUseCaseTest {
+    @Mock
+    private ApprovedLoanRequestMetricsEventPublisher publisher;
+
+    @InjectMocks
+    private SendLoanApplicationApprovedMetricsNotificationUseCase useCase;
+
+    @Test
+    void execute_ShouldPublishNotification() {
+        var approvedLoanCount = 5L;
+        var approvedLoanAmount = new java.math.BigDecimal("10000.00");
+        var input = new SendLoanApplicationApprovedMetricsNotificationUseCaseInput(
+                approvedLoanCount,
+                approvedLoanAmount
+        );
+
+        when(publisher.publishNotification(any())).thenReturn(Mono.empty());
+
+        Mono<Void> result = useCase.execute(input);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+
+        verify(publisher, times(1)).publishNotification(any());
+    }
+}

--- a/infrastructure/driven-adapters/sqs-sender/build.gradle
+++ b/infrastructure/driven-adapters/sqs-sender/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework.boot:spring-boot-autoconfigure'
+    implementation 'org.apache.logging.log4j:log4j-api'
+    implementation 'software.amazon.awssdk:sqs'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/SQSSender.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/SQSSender.java
@@ -1,0 +1,43 @@
+package co.com.crediya.sqs.sender;
+
+import co.com.crediya.model.approvedloanrequestmetric.events.ApprovedLoanRequestMetricsNotificationEvent;
+import co.com.crediya.model.approvedloanrequestmetric.gateways.ApprovedLoanRequestMetricsEventPublisher;
+import co.com.crediya.sqs.sender.config.SQSSenderProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class SQSSender implements ApprovedLoanRequestMetricsEventPublisher {
+    private final SQSSenderProperties properties;
+    private final SqsAsyncClient client;
+    private final ObjectMapper objectMapper;
+
+    public Mono<String> send(String message, String queueUrl) {
+        return Mono.fromCallable(() -> buildRequest(message, queueUrl))
+                .doOnNext(json -> log.info("Mapped JSON message to send: {}", json))
+                .flatMap(request -> Mono.fromFuture(client.sendMessage(request)))
+                .map(SendMessageResponse::messageId);
+    }
+
+    private SendMessageRequest buildRequest(String message, String queueUrl) {
+        return SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(message)
+                .build();
+    }
+
+    @Override
+    public Mono<Void> publishNotification(ApprovedLoanRequestMetricsNotificationEvent event) {
+        return Mono.fromCallable(() -> objectMapper.writeValueAsString(event))
+                .flatMap(msg -> send(msg, properties.metricsNotificationQueueUrl()))
+                .then();
+    }
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/config/SQSSenderConfig.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/config/SQSSenderConfig.java
@@ -1,0 +1,50 @@
+package co.com.crediya.sqs.sender.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.net.URI;
+
+@Configuration
+@ConditionalOnMissingBean(SqsAsyncClient.class)
+public class SQSSenderConfig {
+
+    @Bean
+    public SqsAsyncClient configSqs(SQSSenderProperties properties, MetricPublisher publisher) {
+        return SqsAsyncClient.builder()
+                .endpointOverride(resolveEndpoint(properties))
+                .region(Region.of(properties.region()))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .credentialsProvider(getProviderChain())
+                .build();
+    }
+
+    private AwsCredentialsProviderChain getProviderChain() {
+        return AwsCredentialsProviderChain.builder()
+                .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
+                .addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .addCredentialsProvider(ProfileCredentialsProvider.create())
+                .addCredentialsProvider(ContainerCredentialsProvider.builder().build())
+                .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+                .build();
+    }
+
+    private URI resolveEndpoint(SQSSenderProperties properties) {
+        if (properties.endpoint() != null) {
+            return URI.create(properties.endpoint());
+        }
+        return null;
+    }
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/config/SQSSenderProperties.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/crediya/sqs/sender/config/SQSSenderProperties.java
@@ -1,0 +1,10 @@
+package co.com.crediya.sqs.sender.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "adapter.sqs")
+public record SQSSenderProperties(
+     String region,
+     String metricsNotificationQueueUrl,
+     String endpoint){
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/crediya/sqs/sender/SQSSenderTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/crediya/sqs/sender/SQSSenderTest.java
@@ -1,0 +1,74 @@
+package co.com.crediya.sqs.sender;
+
+
+import co.com.crediya.model.approvedloanrequestmetric.events.ApprovedLoanRequestMetricsNotificationEvent;
+import co.com.crediya.sqs.sender.config.SQSSenderProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SQSSenderTest {
+    @Mock
+    private SQSSenderProperties properties;
+
+    @Mock
+    private SqsAsyncClient client;
+
+    private ObjectMapper objectMapper;
+
+    private SQSSender sqsSender;
+
+    private ApprovedLoanRequestMetricsNotificationEvent event;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = spy(new ObjectMapper());
+        sqsSender = new SQSSender(properties, client, objectMapper);
+
+        event = new ApprovedLoanRequestMetricsNotificationEvent(
+                5L,
+                new BigDecimal("500000"),
+                new Date()
+        );
+    }
+
+    @Test
+    void publishNotificationShouldSendEventSuccessfully() throws JsonProcessingException {
+        var response = SendMessageResponse
+                .builder().messageId("msg-123").build();
+        when(client.sendMessage(any(SendMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        StepVerifier.create(sqsSender.publishNotification(event))
+                .verifyComplete();
+
+        verify(objectMapper).writeValueAsString(event);
+        verify(client).sendMessage(any(SendMessageRequest.class));
+    }
+
+    @Test
+    void publishNotificationShouldReturnErrorOnJsonProcessingException() throws JsonProcessingException {
+        when(objectMapper.writeValueAsString(any()))
+                .thenThrow(new JsonProcessingException("JSON error") { });
+
+        StepVerifier.create(sqsSender.publishNotification(event))
+                .expectError(JsonProcessingException.class)
+                .verify();
+    }
+}

--- a/infrastructure/entry-points/metrics-notifications/build.gradle
+++ b/infrastructure/entry-points/metrics-notifications/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter'
+}

--- a/infrastructure/entry-points/metrics-notifications/src/main/java/co/com/crediya/metricsnotifications/scheduler/LoanRequestsApprovedMetricsNotificationScheduler.java
+++ b/infrastructure/entry-points/metrics-notifications/src/main/java/co/com/crediya/metricsnotifications/scheduler/LoanRequestsApprovedMetricsNotificationScheduler.java
@@ -1,0 +1,37 @@
+package co.com.crediya.metricsnotifications.scheduler;
+
+import co.com.crediya.usecase.getapprovedloanapplicationamount.GetApprovedLoanApplicationAmountUseCase;
+import co.com.crediya.usecase.getapprovedloanapplicationcount.GetApprovedLoanApplicationCountUseCase;
+import co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification.SendLoanApplicationApprovedMetricsNotificationUseCase;
+import co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification.SendLoanApplicationApprovedMetricsNotificationUseCaseInput;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoanRequestsApprovedMetricsNotificationScheduler {
+    private final GetApprovedLoanApplicationAmountUseCase getApprovedLoanApplicationAmountUseCase;
+    private final GetApprovedLoanApplicationCountUseCase getApprovedLoanApplicationCountUseCase;
+    private final SendLoanApplicationApprovedMetricsNotificationUseCase sendNotificationUseCase;
+
+    @Scheduled(cron = "0 0 20 * * *", zone = "${app.tz}") // At 8:00 PM daily using app timezone
+    public void publishDailyReport() {
+        Mono.zip(
+                        getApprovedLoanApplicationCountUseCase.execute(null),
+                        getApprovedLoanApplicationAmountUseCase.execute(null)
+                ).flatMap(tuple -> {
+                    var input = new SendLoanApplicationApprovedMetricsNotificationUseCaseInput(
+                            tuple.getT1(),
+                            tuple.getT2()
+                    );
+
+                    return sendNotificationUseCase.execute(input);
+                }).doOnSuccess(v -> log.info("[metrics-notifications] Daily approved loans report published successfully."))
+                .doOnError(e -> log.error("[metrics-notifications] Error publishing daily approved loans report", e))
+                .subscribe();
+    }
+}

--- a/infrastructure/entry-points/metrics-notifications/src/test/java/co/com/crediya/metricsnotifications/scheduler/LoanRequestsApprovedMetricsNotificationSchedulerTest.java
+++ b/infrastructure/entry-points/metrics-notifications/src/test/java/co/com/crediya/metricsnotifications/scheduler/LoanRequestsApprovedMetricsNotificationSchedulerTest.java
@@ -1,0 +1,51 @@
+package co.com.crediya.metricsnotifications.scheduler;
+
+
+import co.com.crediya.usecase.getapprovedloanapplicationamount.GetApprovedLoanApplicationAmountUseCase;
+import co.com.crediya.usecase.getapprovedloanapplicationcount.GetApprovedLoanApplicationCountUseCase;
+import co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification.SendLoanApplicationApprovedMetricsNotificationUseCase;
+import co.com.crediya.usecase.sendloanapplicationapprovedmetricsnotification.SendLoanApplicationApprovedMetricsNotificationUseCaseInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoanRequestsApprovedMetricsNotificationSchedulerTest {
+    @Mock
+    private GetApprovedLoanApplicationAmountUseCase amountUseCase;
+
+    @Mock
+    private GetApprovedLoanApplicationCountUseCase countUseCase;
+
+    @Mock
+    private SendLoanApplicationApprovedMetricsNotificationUseCase sendNotificationUseCase;
+
+    @InjectMocks
+    private LoanRequestsApprovedMetricsNotificationScheduler scheduler;
+
+    @Test
+    void testPublishDailyReport() {
+        when(countUseCase.execute(any())).thenReturn(Mono.just(5L));
+        when(amountUseCase.execute(any())).thenReturn(Mono.just(new BigDecimal("100000")));
+        when(sendNotificationUseCase.execute(any())).thenReturn(Mono.empty());
+
+        var result = Mono.fromRunnable(() -> scheduler.publishDailyReport());
+        StepVerifier.create(result).verifyComplete();
+
+        verify(sendNotificationUseCase).execute(
+                new SendLoanApplicationApprovedMetricsNotificationUseCaseInput(
+                        5L,
+                        new BigDecimal("100000")
+                )
+        );
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validator/jwt/JwtProperties.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validator/jwt/JwtProperties.java
@@ -1,4 +1,4 @@
-package co.com.crediya.api.provider.jwt;
+package co.com.crediya.api.validator.jwt;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validator/jwt/JwtTokenValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validator/jwt/JwtTokenValidator.java
@@ -1,4 +1,4 @@
-package co.com.crediya.api.provider.jwt;
+package co.com.crediya.api.validator.jwt;
 
 import co.com.crediya.api.contract.TokenValidator;
 import co.com.crediya.api.dto.common.ClaimsDTO;

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/validator/jwt/JwtTokenValidatorTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/validator/jwt/JwtTokenValidatorTest.java
@@ -1,7 +1,7 @@
-package co.com.crediya.provider.jwt;
+package co.com.crediya.validator.jwt;
 
-import co.com.crediya.api.provider.jwt.JwtProperties;
-import co.com.crediya.api.provider.jwt.JwtTokenValidator;
+import co.com.crediya.api.validator.jwt.JwtProperties;
+import co.com.crediya.api.validator.jwt.JwtTokenValidator;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/config/SQSConfig.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/config/SQSConfig.java
@@ -1,6 +1,7 @@
 package co.com.crediya.sqs.listener.config;
 
 import co.com.crediya.sqs.listener.helper.SQSListener;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import reactor.core.publisher.Mono;
@@ -20,6 +21,7 @@ import java.net.URI;
 import java.util.function.Function;
 
 @Configuration
+@ConditionalOnMissingBean(SqsAsyncClient.class)
 public class SQSConfig {
 
     @Bean

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/config/SQSProperties.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/config/SQSProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record SQSProperties(
         String region,
         String endpoint,
-        String queueUrl,
+        String approvedQueueUrl,
         int waitTimeSeconds,
         int visibilityTimeoutSeconds,
         int maxNumberOfMessages,

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/helper/SQSListener.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/crediya/sqs/listener/helper/SQSListener.java
@@ -24,7 +24,7 @@ public class SQSListener {
     private String operation;
 
     public SQSListener start() {
-        this.operation = "MessageFrom:" + properties.queueUrl();
+        this.operation = "MessageFrom:" + properties.approvedQueueUrl();
         ExecutorService service = Executors.newFixedThreadPool(properties.numberOfThreads());
         Flux<Void> flow = listenRetryRepeat().publishOn(Schedulers.fromExecutorService(service));
         for (var i = 0; i < properties.numberOfThreads(); i++) {
@@ -64,7 +64,7 @@ public class SQSListener {
 
     private ReceiveMessageRequest getReceiveMessageRequest() {
         return ReceiveMessageRequest.builder()
-                .queueUrl(properties.queueUrl())
+                .queueUrl(properties.approvedQueueUrl())
                 .maxNumberOfMessages(properties.maxNumberOfMessages())
                 .waitTimeSeconds(properties.waitTimeSeconds())
                 .visibilityTimeout(properties.visibilityTimeoutSeconds())
@@ -73,7 +73,7 @@ public class SQSListener {
 
     private DeleteMessageRequest getDeleteMessageRequest(String receiptHandle) {
         return DeleteMessageRequest.builder()
-                .queueUrl(properties.queueUrl())
+                .queueUrl(properties.approvedQueueUrl())
                 .receiptHandle(receiptHandle)
                 .build();
     }

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/crediya/sqs/listener/config/SQSConfigTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/crediya/sqs/listener/config/SQSConfigTest.java
@@ -27,7 +27,7 @@ class SQSConfigTest {
     void init() {
         MockitoAnnotations.openMocks(this);
         when(sqsProperties.region()).thenReturn("us-east-1");
-        when(sqsProperties.queueUrl()).thenReturn("http://localhost:4566/00000000000/queue-sqs");
+        when(sqsProperties.approvedQueueUrl()).thenReturn("http://localhost:4566/00000000000/queue-sqs");
         when(sqsProperties.waitTimeSeconds()).thenReturn(20);
         when(sqsProperties.maxNumberOfMessages()).thenReturn(10);
         when(sqsProperties.numberOfThreads()).thenReturn(1);

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,3 +28,7 @@ include ':dynamo-db'
 project(':dynamo-db').projectDir = file('./infrastructure/driven-adapters/dynamo-db')
 include ':sqs-listener'
 project(':sqs-listener').projectDir = file('./infrastructure/entry-points/sqs-listener')
+include ':metrics-notifications'
+project(':metrics-notifications').projectDir = file('./infrastructure/entry-points/metrics-notifications')
+include ':sqs-sender'
+project(':sqs-sender').projectDir = file('./infrastructure/driven-adapters/sqs-sender')


### PR DESCRIPTION
## Description
Implementar la visualización del rendimiento total del negocio por medio de un correo. Esto permitirá al administrador la toma de decisiones estratégicas de manera informada.

## Included Changes

- Add event and publisher for approved loan request metrics.
- Add use case for sending approved loan metrics notifications.
- Refactor JWT classes into `validator` package for better organization.
- Add SQS sender adapter for approved loan metrics notifications.
- Rename `queueUrl` to `approvedQueueUrl` and avoid bean conflicts (SQS Properties Bean).
- Add scheduler for daily approved loans metrics notification with configurable timezone.
- Add metrics-notifications and sqs-sender modules to infrastructure layer.
- Enable scheduling in Spring Boot application.

## Checklist
- [x] Diseño siguiendo arquitectura Hexagonal  
- [x] Cumple criterios de aceptación  
- [x] Tests unitarios con cobertura >90%  
- [x] Documentación de endpoints (parámetros y salidas)  
- [x] Manejo de excepciones de forma reactiva  
- [x] Buenas prácticas aplicadas  